### PR TITLE
Turning on the RSS feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+gems:
+- jekyll-feed


### PR DESCRIPTION
Now that Github finally supports them for Jekyll-powered GIthub Pages!

https://help.github.com/articles/using-jekyll-plugins-with-github-pages/